### PR TITLE
optimisation: crawler (almost*) skips all routes that do not have the…

### DIFF
--- a/src/LaravelStaticServiceProvider.php
+++ b/src/LaravelStaticServiceProvider.php
@@ -2,10 +2,12 @@
 
 namespace Vormkracht10\LaravelStatic;
 
+use Illuminate\Contracts\Http\Kernel;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Vormkracht10\LaravelStatic\Commands\StaticBuildCommand;
 use Vormkracht10\LaravelStatic\Commands\StaticClearCommand;
+use Vormkracht10\LaravelStatic\Middleware\PreventStaticResponseMiddleware;
 
 class LaravelStaticServiceProvider extends PackageServiceProvider
 {
@@ -18,5 +20,14 @@ class LaravelStaticServiceProvider extends PackageServiceProvider
                 StaticClearCommand::class,
                 StaticBuildCommand::class,
             ]);
+    }
+
+    public function packageBooted()
+    {
+        $kernel = $this->app->make(Kernel::class);
+
+        $kernel->prependMiddlewareToGroup('web',
+            PreventStaticResponseMiddleware::class
+        );
     }
 }

--- a/src/Middleware/PreventStaticResponseMiddleware.php
+++ b/src/Middleware/PreventStaticResponseMiddleware.php
@@ -14,9 +14,9 @@ class PreventStaticResponseMiddleware
 
         $key = array_key_first($bypass);
 
-        $value = $bypass[$key];
+        $value = $bypass[$key] ?? null;
 
-        if (! $request->header($key) === $value) {
+        if (! $value || $request->header($key) !== $value) {
             return $next($request);
         }
 

--- a/src/Middleware/PreventStaticResponseMiddleware.php
+++ b/src/Middleware/PreventStaticResponseMiddleware.php
@@ -22,12 +22,12 @@ class PreventStaticResponseMiddleware
 
         $route = Route::current();
 
-        $shouldHandle = in_array(
+        $hasStaticResponseMiddleware = in_array(
             StaticResponse::class,
             Route::gatherRouteMiddleware($route),
         );
 
-        if (! $shouldHandle) {
+        if (! $hasStaticResponseMiddleware) {
             return response(status: 200);
         }
 

--- a/src/Middleware/PreventStaticResponseMiddleware.php
+++ b/src/Middleware/PreventStaticResponseMiddleware.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Vormkracht10\LaravelStatic\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+class PreventStaticResponseMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $bypass = config('static.build.bypass_header');
+
+        $key = array_key_first($bypass);
+
+        $value = $bypass[$key];
+
+        if (! $request->header($key) === $value) {
+            return $next($request);
+        }
+
+        $route = Route::current();
+
+        $shouldHandle = in_array(
+            StaticResponse::class,
+            Route::gatherRouteMiddleware($route),
+        );
+
+        if (! $shouldHandle) {
+            return response(status: 200);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
… `static` middleware.

* it still boots the application, but cuts the request short before running any user-defined logic and middleware.