### PR TITLE
Add support for spatie/crawler v9

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,12 +13,20 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1]
-        laravel: [9.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          # Laravel 13 requires PHP >= 8.3
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ phpstan.neon
 testbench.yaml
 vendor
 node_modules
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Traditional Laravel applications generate HTML on every request, hitting your da
 
 - PHP 8.1 or higher
 - Laravel 11.0 or higher
+- spatie/crawler v8 or v9 (Composer picks v9 automatically on PHP 8.4+; v8 is used on PHP 8.1–8.3)
 
 ## Installation
 
@@ -250,7 +251,12 @@ StaticCache::clear(['/about', '/contact']);
 
 ### Custom Crawl Observer
 
-Create a custom crawl observer to customize the crawling behavior:
+Create a custom crawl observer to customize the crawling behavior.
+
+> **Note:** the observer must extend the `CrawlObserver` of the spatie/crawler
+> major version you have installed — the method signatures differ between v8
+> (PSR `UriInterface`/`ResponseInterface` parameters) and v9 (string URLs,
+> `CrawlResponse`, `CrawlProgress`). The example below uses the v8 signatures:
 
 ```php
 namespace App\Crawlers;

--- a/composer.json
+++ b/composer.json
@@ -19,19 +19,19 @@
         "php": "^8.1",
         "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
         "laravel/helpers": "^1.6",
-        "spatie/crawler": "^8.0",
+        "spatie/crawler": "^8.0 || ^9.0",
         "spatie/laravel-package-tools": "^1.15.0",
         "voku/html-min": "^5.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^8.5",
-        "larastan/larastan": "^2.0.1",
-        "orchestra/testbench": "^9.0",
-        "pestphp/pest": "^3.5",
-        "pestphp/pest-plugin-laravel": "^3.0",
+        "larastan/larastan": "^2.0.1 || ^3.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "pestphp/pest": "^3.5 || ^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0 || ^4.0",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan-deprecation-rules": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,16 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+			identifier: larastan.noEnvCallsOutsideOfConfig
+			count: 3
+			path: config/static.php
+
+		-
+			message: '''
+				#^Call to deprecated method forceRootUrl\(\) of class Illuminate\\Routing\\UrlGenerator\:
+				Use useOrigin$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Commands/StaticBuildCommand.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,8 +6,13 @@ parameters:
     paths:
         - src
         - config
+    excludePaths:
+        # Version-specific spatie/crawler code: only one crawler major is
+        # installed at analysis time, so the other file cannot type-check.
+        - src/Crawler/StaticCrawlObserver.php
+        - src/Crawler/CrawlerV8Runner.php
+        - src/Crawler/CrawlerV9Runner.php
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,39 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    executionOrder="random"
-    failOnWarning="true"
-    failOnRisky="true"
-    failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    verbose="true"
->
-    <testsuites>
-        <testsuite name="Backstage Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Backstage Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Commands/StaticBuildCommand.php
+++ b/src/Commands/StaticBuildCommand.php
@@ -2,8 +2,11 @@
 
 namespace Backstage\Static\Laravel\Commands;
 
+use Backstage\Static\Laravel\Crawler\CrawlerV8Runner;
+use Backstage\Static\Laravel\Crawler\CrawlerV9Runner;
+use Backstage\Static\Laravel\Middleware\StaticResponse;
+use Backstage\Static\Laravel\StaticCache;
 use Exception;
-use GuzzleHttp\RequestOptions;
 use Illuminate\Config\Repository;
 use Illuminate\Console\Command;
 use Illuminate\Http\Request;
@@ -11,8 +14,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Spatie\Crawler\Crawler;
-use Backstage\Static\Laravel\StaticCache;
-use Backstage\Static\Laravel\Middleware\StaticResponse;
 
 class StaticBuildCommand extends Command
 {
@@ -93,33 +94,14 @@ class StaticBuildCommand extends Command
 
     public function cacheWithCrawler(): void
     {
-        $bypassHeader = $this->config->get('static.build.bypass_header');
+        // spatie/crawler v9 introduced addObserver() as part of its API
+        // rework; its presence tells the two majors apart. PHPStan analyses
+        // against a single installed major, so it sees this as constant.
+        // @phpstan-ignore function.alreadyNarrowedType
+        $runner = method_exists(Crawler::class, 'addObserver')
+            ? new CrawlerV9Runner($this->config, $this->components)
+            : new CrawlerV8Runner($this->config, $this->components);
 
-        $profile = new ($this->config->get('static.build.crawl_profile'))(
-            $this->config->get('app.url'),
-        );
-
-        $observer = new ($this->config->get('static.build.crawl_observer'))(
-            $this->components,
-        );
-
-        $crawler = Crawler::create([
-            RequestOptions::VERIFY => ! app()->environment('local', 'testing'),
-            RequestOptions::ALLOW_REDIRECTS => true,
-            RequestOptions::HEADERS => [
-                array_key_first($bypassHeader) => array_shift($bypassHeader),
-                'User-Agent' => 'LaravelStatic/1.0',
-            ],
-        ])
-            ->setCrawlObserver($observer)
-            ->setCrawlProfile($profile)
-            ->setConcurrency($this->config->get('static.build.concurrency'))
-            ->setDefaultScheme($this->config->get('static.build.default_scheme'));
-
-        if ($this->config->get('static.build.accept_no_follow')) {
-            $crawler->acceptNofollowLinks();
-        }
-
-        $crawler->startCrawling($this->config->get('app.url'));
+        $runner->crawl();
     }
 }

--- a/src/Crawler/CrawlerV8Runner.php
+++ b/src/Crawler/CrawlerV8Runner.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Backstage\Static\Laravel\Crawler;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Config\Repository;
+use Illuminate\Console\View\Components\Factory as ComponentFactory;
+use Spatie\Crawler\Crawler;
+
+/**
+ * Runs the site crawl using the spatie/crawler v8 API.
+ *
+ * Version-specific: excluded from static analysis, since only one
+ * spatie/crawler major version is installed at a time.
+ */
+class CrawlerV8Runner
+{
+    public function __construct(
+        protected Repository $config,
+        protected ComponentFactory $components,
+    ) {}
+
+    public function crawl(): void
+    {
+        $bypassHeader = $this->config->get('static.build.bypass_header');
+
+        $profile = new ($this->config->get('static.build.crawl_profile'))(
+            $this->config->get('app.url'),
+        );
+
+        $observer = new ($this->config->get('static.build.crawl_observer'))(
+            $this->components,
+        );
+
+        $crawler = Crawler::create([
+            RequestOptions::VERIFY => ! app()->environment('local', 'testing'),
+            RequestOptions::ALLOW_REDIRECTS => true,
+            RequestOptions::HEADERS => [
+                array_key_first($bypassHeader) => array_shift($bypassHeader),
+                'User-Agent' => 'LaravelStatic/1.0',
+            ],
+        ])
+            ->setCrawlObserver($observer)
+            ->setCrawlProfile($profile)
+            ->setConcurrency($this->config->get('static.build.concurrency'))
+            ->setDefaultScheme($this->config->get('static.build.default_scheme'));
+
+        if ($this->config->get('static.build.accept_no_follow')) {
+            $crawler->acceptNofollowLinks();
+        }
+
+        $crawler->startCrawling($this->config->get('app.url'));
+    }
+}

--- a/src/Crawler/CrawlerV9Runner.php
+++ b/src/Crawler/CrawlerV9Runner.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Backstage\Static\Laravel\Crawler;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Config\Repository;
+use Illuminate\Console\View\Components\Factory as ComponentFactory;
+use Spatie\Crawler\Crawler;
+
+/**
+ * Runs the site crawl using the spatie/crawler v9 API.
+ *
+ * Version-specific: excluded from static analysis, since only one
+ * spatie/crawler major version is installed at a time.
+ */
+class CrawlerV9Runner
+{
+    public function __construct(
+        protected Repository $config,
+        protected ComponentFactory $components,
+    ) {}
+
+    public function crawl(): void
+    {
+        $bypassHeader = $this->config->get('static.build.bypass_header');
+
+        $crawler = Crawler::create($this->config->get('app.url'), [
+            RequestOptions::VERIFY => ! app()->environment('local', 'testing'),
+            RequestOptions::ALLOW_REDIRECTS => true,
+            RequestOptions::HEADERS => [
+                array_key_first($bypassHeader) => array_shift($bypassHeader),
+                'User-Agent' => 'LaravelStatic/1.0',
+            ],
+        ])
+            ->crawlProfile(new ($this->config->get('static.build.crawl_profile'))(
+                $this->config->get('app.url'),
+            ))
+            ->concurrency($this->config->get('static.build.concurrency'))
+            ->defaultScheme($this->config->get('static.build.default_scheme'));
+
+        if ($this->config->get('static.build.accept_no_follow')) {
+            $crawler->followNofollow();
+        }
+
+        $observer = $this->config->get('static.build.crawl_observer');
+
+        if ($observer && $observer !== StaticCrawlObserver::class) {
+            // A custom observer must extend crawler v9's CrawlObserver.
+            $crawler->addObserver(new $observer($this->components));
+        } else {
+            // The default StaticCrawlObserver targets the v8 observer
+            // signatures and cannot load on v9; closures replace it.
+            $crawler
+                ->onCrawled(fn (string $url) => $this->components->info('Crawled and cached url: '.$url))
+                ->onFailed(fn (string $url) => $this->components->error('Failed to crawl url: '.$url))
+                ->onFinished(fn () => $this->components->info('Static cache build completed'));
+        }
+
+        $crawler->start();
+    }
+}


### PR DESCRIPTION
## Why

spatie/crawler v9 requires PHP 8.4 and reworked the public API. Staying pinned to `^8.0` blocks consumers from combining laravel-static with anything that needs crawler v9 — most notably `spatie/laravel-sitemap >= 8.0.1`, a very common companion package (that's how this surfaced: markvaneijk.com couldn't install both).

## What

`composer.json` now allows `spatie/crawler: ^8.0 || ^9.0`:
- PHP 8.1–8.3 keeps resolving crawler v8 — behaviour unchanged
- PHP 8.4+ resolves v9

Since v9 renamed the fluent API (`Crawler::create($url)`, `crawlProfile()`, `concurrency()`, `defaultScheme()`, `followNofollow()`, `start()`) and changed the observer contract, the crawl in `static:build` is delegated to a version-specific runner picked at runtime via `method_exists(Crawler::class, 'addObserver')`:

- **`CrawlerV8Runner`** — the existing v8 code, extracted verbatim
- **`CrawlerV9Runner`** — v9 API; the default logging observer is replaced with v9's closure hooks (`onCrawled`/`onFailed`/`onFinished`), and a custom `crawl_observer` from config is passed through via `addObserver()` (it must extend the installed major's `CrawlObserver` — documented in the README)

PHPStan can only analyse against the single installed crawler major, so the three version-specific files are excluded from analysis.

## Supporting fixes (needed to get CI meaningful again)

- **`phpunit.xml.dist` was still on the PHPUnit 9 schema** — under PHPUnit 12 the suite silently ran **zero tests and exited 0**. Migrated the schema and dropped the stale coverage-report config that caused the silent abort.
- **Test matrix** was PHP 8.1 / Laravel 9, which current constraints can't even install. Now PHP 8.2–8.4 × Laravel 11–13 × prefer-lowest/stable, which also exercises both crawler majors (8.4 + prefer-stable → v9, everything else → v8).
- Dev dependencies widened (testbench 9–11, pest 3–4, larastan 2–3); phpstan CI pinned to PHP 8.4; two pre-existing findings surfaced by larastan 3 baselined (`env()` calls in config, deprecated `forceRootUrl()`).

## Verified

- `pest`: 7 passed (18 assertions) against **crawler 9.3.2** (Laravel 13, PHP 8.4)
- `pest`: 7 passed (18 assertions) against **crawler 8.5.0** (same environment, pinned)
- Runner detection returns V8/V9 correctly per installed version; `StaticCrawlObserver` still loads fine under v8
- `phpstan`: no errors
- `pint`: touched files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)