### PR TITLE
Add targeted single-page build (StaticCache::build, BuildStaticPage job, static:build {url?})

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ phpstan.neon
 testbench.yaml
 vendor
 node_modules
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ php artisan static:build
 
 When using the `routes` driver, only routes with the `StaticResponse` middleware are cached. When using the `crawler` driver, the crawler starts from your homepage and discovers all internal links.
 
+Rebuild a single page instead of crawling the whole site — the targeted
+counterpart to `static:clear --uri`:
+
+```bash
+php artisan static:build https://example.com/blog/my-post
+```
+
+The page is re-rendered through its own route (no clear, no crawl), so only that
+one cached file is refreshed.
+
 ### Clear Static Cache
 
 Clear all cached static files:
@@ -247,6 +257,37 @@ StaticCache::clear();
 // Clear specific paths
 StaticCache::clear(['/about', '/contact']);
 ```
+
+### Programmatic Page Building
+
+Refresh one or more pages without rebuilding the whole site. Each URL is
+re-rendered through its own route, so only those cached files are written — the
+targeted counterpart to `clear()`:
+
+```php
+use Backstage\Static\Laravel\Facades\StaticCache;
+
+// Rebuild a single page
+StaticCache::build('https://example.com/blog/my-post');
+
+// Rebuild several at once
+StaticCache::build([
+    'https://example.com/blog/my-post',
+    'https://example.com/blog',
+]);
+```
+
+To do this off the request cycle, dispatch the queued `BuildStaticPage` job:
+
+```php
+use Backstage\Static\Laravel\Jobs\BuildStaticPage;
+
+BuildStaticPage::dispatch($post->url());
+```
+
+The job is a no-op when static caching is disabled, and a failed render is
+reported rather than thrown — the page keeps its previous cached copy until the
+next build.
 
 ### Custom Crawl Observer
 
@@ -425,6 +466,18 @@ class Post extends Model
         });
     }
 }
+```
+
+Prefer re-rendering the changed page over clearing it when you want the cache to
+stay warm. Dispatch the `BuildStaticPage` job so the edited page is rebuilt
+immediately instead of being regenerated lazily on the next visit:
+
+```php
+use Backstage\Static\Laravel\Jobs\BuildStaticPage;
+
+static::updated(function (Post $post) {
+    BuildStaticPage::dispatch($post->url());
+});
 ```
 
 ### Scheduled Rebuilds

--- a/src/Commands/StaticBuildCommand.php
+++ b/src/Commands/StaticBuildCommand.php
@@ -2,6 +2,8 @@
 
 namespace Backstage\Static\Laravel\Commands;
 
+use Backstage\Static\Laravel\Middleware\StaticResponse;
+use Backstage\Static\Laravel\StaticCache;
 use Exception;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Config\Repository;
@@ -11,12 +13,10 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Spatie\Crawler\Crawler;
-use Backstage\Static\Laravel\StaticCache;
-use Backstage\Static\Laravel\Middleware\StaticResponse;
 
 class StaticBuildCommand extends Command
 {
-    public $signature = 'static:build';
+    public $signature = 'static:build {url? : Build only this URL instead of crawling the whole site}';
 
     public $description = 'Build Static version';
 
@@ -34,6 +34,16 @@ class StaticBuildCommand extends Command
 
     public function handle(): void
     {
+        // A single URL rebuilds just that page: no clear, no crawl — the
+        // targeted counterpart to `static:clear -u`.
+        if ($url = $this->argument('url')) {
+            $this->static->build($url);
+
+            $this->components->info('Built static cache for: '.$url);
+
+            return;
+        }
+
         if ($this->config->get('static.build.clear_before_start')) {
             $this->call(StaticClearCommand::class);
         }

--- a/src/Facades/StaticCache.php
+++ b/src/Facades/StaticCache.php
@@ -5,7 +5,11 @@ namespace Backstage\Static\Laravel\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \Vormkracht10\LaravelStatic\LaravelStatic
+ * @method static bool clear(?array $paths = null)
+ * @method static void build(string|array $urls)
+ * @method static \Illuminate\Contracts\Filesystem\Filesystem disk(?string $override = null)
+ *
+ * @see \Backstage\Static\Laravel\StaticCache
  */
 class StaticCache extends Facade
 {

--- a/src/Jobs/BuildStaticPage.php
+++ b/src/Jobs/BuildStaticPage.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Backstage\Static\Laravel\Jobs;
+
+use Backstage\Static\Laravel\Facades\StaticCache;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Throwable;
+
+/**
+ * Queued, targeted refresh of a single page's static cache. Dispatch this after
+ * the data behind a page changes to re-render just that URL, instead of clearing
+ * and rebuilding the whole site:
+ *
+ *     BuildStaticPage::dispatch($model->url());
+ *
+ * A no-op when static caching is disabled, and a failed render is reported
+ * rather than thrown — the page simply keeps its previous cached copy until the
+ * next build.
+ */
+class BuildStaticPage implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public string $url) {}
+
+    public function handle(): void
+    {
+        if (! config('static.enabled')) {
+            return;
+        }
+
+        try {
+            StaticCache::build($this->url);
+        } catch (Throwable $e) {
+            report($e);
+        }
+    }
+}

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -5,6 +5,8 @@ namespace Backstage\Static\Laravel;
 use Illuminate\Config\Repository;
 use Illuminate\Filesystem\Filesystem as Files;
 use Illuminate\Filesystem\FilesystemManager as Storage;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 class StaticCache
 {
@@ -21,6 +23,29 @@ class StaticCache
         }
 
         return $this->files->cleanDirectory($this->disk()->getConfig()['root']);
+    }
+
+    /**
+     * Render one or more URLs into the static cache without crawling the whole
+     * site. Each URL is dispatched through its own route so its StaticResponse
+     * middleware writes a fresh file for just that page — the targeted
+     * counterpart to clear(). A URL whose route isn't static-cached simply
+     * writes nothing; a route that aborts (e.g. a 404) throws, so callers that
+     * refresh pages which may have disappeared should guard or catch.
+     *
+     * @param  string|array<int, string>  $urls
+     */
+    public function build(string|array $urls): void
+    {
+        foreach ((array) $urls as $url) {
+            $request = Request::create($url);
+
+            // Match the crawler's fingerprint so the render is identical to a
+            // full `static:build` pass.
+            $request->headers->set('User-Agent', 'LaravelStatic/1.0');
+
+            Route::dispatchToRoute($request);
+        }
     }
 
     public function disk(?string $override = null)

--- a/tests/Feature/BuildStaticPageTest.php
+++ b/tests/Feature/BuildStaticPageTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Backstage\Static\Laravel\Facades\StaticCache;
+use Backstage\Static\Laravel\Jobs\BuildStaticPage;
+use Backstage\Static\Laravel\Middleware\StaticResponse;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    config(['static.files.disk' => 'local']);
+
+    // Isolate each test on its own disk so leftover files never bleed across.
+    Storage::fake('local');
+});
+
+it('builds a single URL into the static cache', function () {
+    Route::get('foo', fn () => 'foo body')
+        ->middleware(StaticResponse::class);
+
+    StaticCache::build('http://localhost/foo');
+
+    $disk = StaticCache::disk();
+
+    $disk->assertExists('localhost/GET/foo?.html');
+    expect($disk->get('localhost/GET/foo?.html'))->toBe('foo body');
+});
+
+it('builds several URLs at once', function () {
+    Route::get('one', fn () => 'one')->middleware(StaticResponse::class);
+    Route::get('two', fn () => 'two')->middleware(StaticResponse::class);
+
+    StaticCache::build(['http://localhost/one', 'http://localhost/two']);
+
+    $disk = StaticCache::disk();
+
+    $disk->assertExists('localhost/GET/one?.html');
+    $disk->assertExists('localhost/GET/two?.html');
+});
+
+it('writes nothing for a route that is not static-cached', function () {
+    Route::get('plain', fn () => 'plain');
+
+    StaticCache::build('http://localhost/plain');
+
+    expect(StaticCache::disk()->allFiles())->toBeEmpty();
+});
+
+it('re-renders a page so the cache reflects fresh content', function () {
+    $body = 'first';
+
+    Route::get('page', function () use (&$body) {
+        return $body;
+    })->middleware(StaticResponse::class);
+
+    StaticCache::build('http://localhost/page');
+    expect(StaticCache::disk()->get('localhost/GET/page?.html'))->toBe('first');
+
+    $body = 'second';
+
+    StaticCache::build('http://localhost/page');
+    expect(StaticCache::disk()->get('localhost/GET/page?.html'))->toBe('second');
+});
+
+it('builds a page from the queued job', function () {
+    Route::get('job', fn () => 'from job')
+        ->middleware(StaticResponse::class);
+
+    (new BuildStaticPage('http://localhost/job'))->handle();
+
+    StaticCache::disk()->assertExists('localhost/GET/job?.html');
+});
+
+it('does nothing from the job when static caching is disabled', function () {
+    config(['static.enabled' => false]);
+
+    Route::get('job', fn () => 'from job')
+        ->middleware(StaticResponse::class);
+
+    (new BuildStaticPage('http://localhost/job'))->handle();
+
+    expect(StaticCache::disk()->allFiles())->toBeEmpty();
+});
+
+it('builds only the given URL via the static:build command', function () {
+    Route::get('cli', fn () => 'cli body')
+        ->middleware(StaticResponse::class);
+
+    $this->artisan('static:build', ['url' => 'http://localhost/cli'])
+        ->assertSuccessful();
+
+    StaticCache::disk()->assertExists('localhost/GET/cli?.html');
+});


### PR DESCRIPTION
## What

Adds a **targeted counterpart to `clear()`**: rebuild one page's static file without crawling the whole site. A single content change (e.g. a product edit) can now refresh just its own page instead of dropping and rebuilding the entire cache.

## API

- **`StaticCache::build(string|array $urls)`** — renders each URL through its own route so the `StaticResponse` middleware writes a fresh file for it. A URL whose route isn't static-cached writes nothing.
- **`Jobs\BuildStaticPage`** (queued) — `BuildStaticPage::dispatch($model->url())`. No-op when static caching is disabled; a failed render is `report()`'d, not thrown.
- **`static:build {url?}`** — builds only the given URL; the CLI counterpart to `static:clear -u`.
- Facade `@method` annotations for `build`/`clear`/`disk` (and fixed the stale `@see`).

## Tests

7 new Pest tests (single/array builds, non-cached route writes nothing, re-render reflects fresh content, the job on/off, the CLI argument). Full suite: **14 passed**. Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)