### PR TITLE
Confirm before clearing static cache (--force to skip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ Clear all cached static files:
 php artisan static:clear
 ```
 
+The command asks for confirmation before clearing. Skip the prompt (e.g. in
+CI/deploy scripts) with `--force`:
+
+```bash
+php artisan static:clear --force
+```
+
 Clear specific URIs:
 
 ```bash

--- a/src/Commands/StaticBuildCommand.php
+++ b/src/Commands/StaticBuildCommand.php
@@ -45,7 +45,7 @@ class StaticBuildCommand extends Command
         }
 
         if ($this->config->get('static.build.clear_before_start')) {
-            $this->call(StaticClearCommand::class);
+            $this->call(StaticClearCommand::class, ['--force' => true]);
         }
 
         if ($this->config->get('static.build.force_root_url')) {

--- a/src/Commands/StaticClearCommand.php
+++ b/src/Commands/StaticClearCommand.php
@@ -11,7 +11,7 @@ use Backstage\Static\Laravel\StaticCache;
 
 class StaticClearCommand extends Command
 {
-    public $signature = 'static:clear {--u|uri=*} {--r|routes=*} {--d|domain=*}';
+    public $signature = 'static:clear {--u|uri=*} {--r|routes=*} {--d|domain=*} {--force : Skip the confirmation prompt}';
 
     public $description = 'Clear static cached files';
 
@@ -20,8 +20,14 @@ class StaticClearCommand extends Command
         parent::__construct();
     }
 
-    public function handle(): void
+    public function handle(): int
     {
+        if (! $this->option('force') && ! $this->confirm('Are you sure you want to clear the static cache?')) {
+            $this->components->info('Static cache clear aborted.');
+
+            return self::SUCCESS;
+        }
+
         $uris = $this->option('uri');
 
         if (! empty($uris)) {
@@ -37,6 +43,8 @@ class StaticClearCommand extends Command
         }
 
         $this->info('✔ Static cache cleared!');
+
+        return self::SUCCESS;
     }
 
     protected function purgeWithRoutes(array $names)


### PR DESCRIPTION
## Summary

`static:clear` now asks for confirmation before wiping the static cache, preventing accidental clears. The prompt can be bypassed with a new `--force` option.

- Added `--force` option and a confirmation prompt to `StaticClearCommand` (applies to all clear modes: all, `--uri`, `--routes`, `--domain`).
- `static:build`'s automated `clear_before_start` step passes `--force` so builds don't hang on the prompt.
- Documented `--force` in the README.

## Test plan

- `php artisan static:clear` → prompts for confirmation; declining aborts cleanly.
- `php artisan static:clear --force` → clears without prompting.
- `php artisan static:build` with `clear_before_start` enabled → clears non-interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)