### PR TITLE
Add gzip/brotli precompression of static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,38 @@ Hostnames are matched against the request host (case-insensitive) and support `*
 ],
 ```
 
+### Precompression (gzip / brotli)
+
+Write precompressed copies of each static file alongside the original so your web
+server can serve them directly, without compressing on every request. gzip is
+built into PHP; brotli requires the [`ext-brotli`](https://github.com/kjdev/php-ext-brotli)
+extension and is silently skipped when it isn't installed.
+
+```php
+'compression' => [
+    'gzip' => true,             // Write a .gz copy (env: STATIC_COMPRESS_GZIP)
+    'gzip_level' => 9,          // 0-9, higher is smaller/slower
+    'brotli' => false,          // Write a .br copy (env: STATIC_COMPRESS_BROTLI)
+    'brotli_level' => 11,       // 0-11
+    'keep_uncompressed' => true, // Also keep the plain .html copy
+],
+```
+
+By default each cached page has `page.html`, `page.html.gz`, and (optionally)
+`page.html.br` siblings. Compression happens once at cache-write time, so a high
+level is usually worth it.
+
+**Storing only the compressed file.** Set `keep_uncompressed` to `false` to skip the
+plain `.html` copy and roughly halve disk usage. The uncompressed file is only
+dropped when a compressed one was actually written, so a page is never left with
+nothing to serve (e.g. brotli requested but `ext-brotli` missing). The trade-off is
+that your web server must then serve the compressed file to **every** client,
+including the rare one that doesn't send `Accept-Encoding: gzip` — with nginx that
+means `gzip_static always;` plus `gunzip on;` to decompress on the fly for those
+clients. If you keep the uncompressed copy, nginx falls back to it automatically.
+
+See [Web Server Configuration](#web-server-configuration) for serving these files.
+
 ## Commands
 
 ### Build Static Cache
@@ -468,6 +500,24 @@ server {
     }
 }
 ```
+
+#### Serving precompressed files
+
+If you enabled [precompression](#precompression-gzip--brotli), turn on nginx's
+static-precompression modules so it serves the `.gz` / `.br` siblings when the
+client supports them. nginx looks for `<file>.gz` / `<file>.br` matching the file
+it's about to serve, so no path changes are needed — just add:
+
+```nginx
+# gzip_static is built into nginx; brotli_static needs the ngx_brotli module.
+gzip_static on;
+brotli_static on;
+```
+
+Place these inside the `server` (or `location`) block above. When a `.br`/`.gz`
+sibling exists and the request carries a matching `Accept-Encoding`, nginx serves
+it and sets `Content-Encoding` automatically; otherwise it falls back to the
+uncompressed file.
 
 ### Apache
 

--- a/config/static.php
+++ b/config/static.php
@@ -127,4 +127,48 @@ return [
          */
         'minify_html' => false,
     ],
+
+    /**
+     * Write precompressed copies of each static file alongside the original, so a
+     * web server can serve them directly without compressing on the fly. nginx does
+     * this with `gzip_static on;` (built in) and `brotli_static on;` (requires the
+     * third-party ngx_brotli module); both look for a `<file>.gz` / `<file>.br`
+     * sibling matching the requested URI.
+     */
+    'compression' => [
+        /**
+         * Write a `.gz` copy of each static file. gzip is built into PHP, so this
+         * has no extra dependencies.
+         */
+        'gzip' => env('STATIC_COMPRESS_GZIP', true),
+
+        /**
+         * Compression level for the `.gz` copy (0-9). Higher is smaller but slower.
+         * Compression happens once at cache-write time, so a high level is usually
+         * worth it.
+         */
+        'gzip_level' => 9,
+
+        /**
+         * Write a `.br` (brotli) copy of each static file. Requires the ext-brotli
+         * PHP extension; when it isn't installed this is silently skipped.
+         */
+        'brotli' => env('STATIC_COMPRESS_BROTLI', false),
+
+        /**
+         * Compression quality for the `.br` copy (0-11). 11 is smallest but slow.
+         */
+        'brotli_level' => 11,
+
+        /**
+         * Also keep the uncompressed copy alongside the compressed one(s). Keeping
+         * it lets the web server fall back to plain output for the rare client that
+         * doesn't accept gzip/brotli. Disable it to store only the compressed file
+         * and halve disk usage — this requires serving the compressed file to every
+         * client (e.g. nginx `gzip_static always;` with `gunzip on;`). Ignored when
+         * no compression format actually produced a file, so a page is never left
+         * with nothing to serve.
+         */
+        'keep_uncompressed' => true,
+    ],
 ];

--- a/config/static.php
+++ b/config/static.php
@@ -1,7 +1,7 @@
 <?php
 
-use Spatie\Crawler\CrawlProfiles\CrawlInternalUrls;
 use Backstage\Static\Laravel\Crawler\StaticCrawlObserver;
+use Spatie\Crawler\CrawlProfiles\CrawlInternalUrls;
 
 return [
     /**

--- a/src/Middleware/StaticResponse.php
+++ b/src/Middleware/StaticResponse.php
@@ -154,9 +154,48 @@ class StaticResponse
             $disk->put('.gitignore', '*' . PHP_EOL . '!.gitignore');
         }
 
-        if ($response->getContent()) {
-            $disk->put($filePath, $response->getContent(), true);
+        if ($content = $response->getContent()) {
+            $wroteCompressed = $this->writeCompressedVariants($disk, $filePath, $content);
+
+            // Skip the uncompressed copy only when precompression actually
+            // produced a file to serve instead — otherwise we'd store nothing
+            // (e.g. brotli requested but ext-brotli missing).
+            if ($wroteCompressed && ! $this->config->get('static.compression.keep_uncompressed', true)) {
+                $disk->delete($filePath);
+            } else {
+                $disk->put($filePath, $content, true);
+            }
         }
+    }
+
+    /**
+     * Write precompressed siblings (.gz / .br) next to the static file so a web
+     * server can serve them directly (e.g. nginx gzip_static / brotli_static)
+     * instead of compressing on every request. Brotli is skipped silently when
+     * the ext-brotli extension isn't installed. Returns whether at least one
+     * compressed file was written.
+     */
+    protected function writeCompressedVariants($disk, string $filePath, string $content): bool
+    {
+        $wrote = false;
+
+        if ($this->config->get('static.compression.gzip')) {
+            $level = (int) $this->config->get('static.compression.gzip_level', 9);
+
+            $disk->put($filePath . '.gz', gzencode($content, $level), true);
+
+            $wrote = true;
+        }
+
+        if ($this->config->get('static.compression.brotli') && function_exists('brotli_compress')) {
+            $level = (int) $this->config->get('static.compression.brotli_level', 11);
+
+            $disk->put($filePath . '.br', brotli_compress($content, $level), true);
+
+            $wrote = true;
+        }
+
+        return $wrote;
     }
 
     /**

--- a/src/Middleware/StaticResponse.php
+++ b/src/Middleware/StaticResponse.php
@@ -2,13 +2,13 @@
 
 namespace Backstage\Static\Laravel\Middleware;
 
+use Backstage\Static\Laravel\Facades\StaticCache;
 use Closure;
 use Illuminate\Config\Repository;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use voku\helper\HtmlMin;
-use Backstage\Static\Laravel\Facades\StaticCache;
 
 class StaticResponse
 {
@@ -151,7 +151,7 @@ class StaticResponse
         $disk = StaticCache::disk();
 
         if (! $disk->exists('.gitignore')) {
-            $disk->put('.gitignore', '*' . PHP_EOL . '!.gitignore');
+            $disk->put('.gitignore', '*'.PHP_EOL.'!.gitignore');
         }
 
         if ($content = $response->getContent()) {
@@ -182,7 +182,7 @@ class StaticResponse
         if ($this->config->get('static.compression.gzip')) {
             $level = (int) $this->config->get('static.compression.gzip_level', 9);
 
-            $disk->put($filePath . '.gz', gzencode($content, $level), true);
+            $disk->put($filePath.'.gz', gzencode($content, $level), true);
 
             $wrote = true;
         }
@@ -190,7 +190,7 @@ class StaticResponse
         if ($this->config->get('static.compression.brotli') && function_exists('brotli_compress')) {
             $level = (int) $this->config->get('static.compression.brotli_level', 11);
 
-            $disk->put($filePath . '.br', brotli_compress($content, $level), true);
+            $disk->put($filePath.'.br', brotli_compress($content, $level), true);
 
             $wrote = true;
         }
@@ -222,7 +222,7 @@ class StaticResponse
         $path = $this->getDiskPath();
 
         if ($this->config->get('static.files.include_domain')) {
-            $path .= '/' . $this->getDomain($request);
+            $path .= '/'.$this->getDomain($request);
         }
 
         return $path;
@@ -230,7 +230,7 @@ class StaticResponse
 
     public function getDiskPath()
     {
-        return rtrim($this->config->get('filesystems.disks.' . $this->config->get('static.files.disk') . '.root'), '/');
+        return rtrim($this->config->get('filesystems.disks.'.$this->config->get('static.files.disk').'.root'), '/');
     }
 
     /**
@@ -260,7 +260,7 @@ class StaticResponse
             return null;
         }
 
-        return '.' . $extension;
+        return '.'.$extension;
     }
 
     /**

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -19,10 +19,25 @@ class StaticCache
     public function clear(?array $paths = null): bool
     {
         if (! is_null($paths)) {
-            return $this->disk()->delete($paths);
+            return $this->disk()->delete($this->withCompressedVariants($paths));
         }
 
         return $this->files->cleanDirectory($this->disk()->getConfig()['root']);
+    }
+
+    /**
+     * Expand a list of static file paths to also include their precompressed
+     * siblings (.gz / .br), so a targeted clear doesn't leave orphaned compressed
+     * copies behind. Deleting a path that doesn't exist is a harmless no-op.
+     *
+     * @param  array<int, string>  $paths
+     * @return array<int, string>
+     */
+    protected function withCompressedVariants(array $paths): array
+    {
+        return collect($paths)
+            ->flatMap(fn (string $path) => [$path, $path . '.gz', $path . '.br'])
+            ->all();
     }
 
     /**

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -36,7 +36,7 @@ class StaticCache
     protected function withCompressedVariants(array $paths): array
     {
         return collect($paths)
-            ->flatMap(fn (string $path) => [$path, $path . '.gz', $path . '.br'])
+            ->flatMap(fn (string $path) => [$path, $path.'.gz', $path.'.br'])
             ->all();
     }
 

--- a/tests/Feature/StaticCacheTest.php
+++ b/tests/Feature/StaticCacheTest.php
@@ -98,6 +98,106 @@ it('caches for any host when the whitelist is null', function () {
     $disk->assertExists('random.test/GET/anywhere?.html');
 });
 
+it('writes a gzip sibling next to the static file', function () {
+    config([
+        'static.files.disk' => 'local',
+        'static.compression.gzip' => true,
+    ]);
+
+    $disk = StaticCache::disk();
+
+    Route::get('gz', fn () => 'gzipped content')
+        ->middleware(StaticResponse::class);
+
+    $this->get('gz');
+
+    $disk->assertExists('localhost/GET/gz?.html');
+    $disk->assertExists('localhost/GET/gz?.html.gz');
+
+    expect(gzdecode($disk->get('localhost/GET/gz?.html.gz')))
+        ->toBe('gzipped content');
+});
+
+it('does not write a gzip sibling when gzip is disabled', function () {
+    config([
+        'static.files.disk' => 'local',
+        'static.compression.gzip' => false,
+    ]);
+
+    $disk = StaticCache::disk();
+
+    Route::get('nogz', fn () => 'plain')
+        ->middleware(StaticResponse::class);
+
+    $this->get('nogz');
+
+    $disk->assertExists('localhost/GET/nogz?.html');
+    $disk->assertMissing('localhost/GET/nogz?.html.gz');
+});
+
+it('stores only the compressed file when keep_uncompressed is disabled', function () {
+    config([
+        'static.files.disk' => 'local',
+        'static.compression.gzip' => true,
+        'static.compression.keep_uncompressed' => false,
+    ]);
+
+    $disk = StaticCache::disk();
+
+    Route::get('only-gz', fn () => 'compressed only')
+        ->middleware(StaticResponse::class);
+
+    $this->get('only-gz');
+
+    $disk->assertMissing('localhost/GET/only-gz?.html');
+    $disk->assertExists('localhost/GET/only-gz?.html.gz');
+
+    expect(gzdecode($disk->get('localhost/GET/only-gz?.html.gz')))
+        ->toBe('compressed only');
+});
+
+it('keeps the uncompressed file when nothing could be compressed', function () {
+    // brotli requested but ext-brotli may be unavailable, and gzip is off, so no
+    // compressed file is produced — the plain copy must survive regardless.
+    config([
+        'static.files.disk' => 'local',
+        'static.compression.gzip' => false,
+        'static.compression.brotli' => false,
+        'static.compression.keep_uncompressed' => false,
+    ]);
+
+    $disk = StaticCache::disk();
+
+    Route::get('fallback', fn () => 'still here')
+        ->middleware(StaticResponse::class);
+
+    $this->get('fallback');
+
+    $disk->assertExists('localhost/GET/fallback?.html');
+    expect($disk->get('localhost/GET/fallback?.html'))->toBe('still here');
+});
+
+it('removes compressed siblings on a targeted clear', function () {
+    config([
+        'static.files.disk' => 'local',
+        'static.compression.gzip' => true,
+    ]);
+
+    $disk = StaticCache::disk();
+
+    Route::get('drop', fn () => 'drop me')
+        ->middleware(StaticResponse::class);
+
+    $this->get('drop');
+
+    $disk->assertExists('localhost/GET/drop?.html.gz');
+
+    StaticCache::clear(['localhost/GET/drop?.html']);
+
+    $disk->assertMissing('localhost/GET/drop?.html');
+    $disk->assertMissing('localhost/GET/drop?.html.gz');
+});
+
 it('minifies HTML', function () {
     config([
         'static.files.disk' => 'local',

--- a/tests/Feature/StaticCacheTest.php
+++ b/tests/Feature/StaticCacheTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use voku\helper\HtmlMin;
 use Backstage\Static\Laravel\Facades\StaticCache;
 use Backstage\Static\Laravel\Middleware\StaticResponse;
+use Illuminate\Support\Facades\Route;
+use voku\helper\HtmlMin;
 
 it('can cache a page response', function ($route) {
     config([


### PR DESCRIPTION
## What

Write precompressed `.gz` / `.br` copies alongside each cached page so a web server can serve them directly (e.g. nginx `gzip_static` / `brotli_static`) instead of compressing on every request.

- **gzip** uses PHP's native `gzencode` — no dependencies. Default on.
- **brotli** requires the `ext-brotli` extension and is silently skipped when it isn't installed. Default off.
- Levels configurable (`gzip_level` 0–9, `brotli_level` 0–11).

## `keep_uncompressed` flag

Default `true`. Set to `false` to skip the plain `.html` copy and roughly halve disk usage. The uncompressed file is only dropped when a compressed one was actually written, so a page is never left with nothing to serve (e.g. brotli requested but `ext-brotli` missing). Compressed-only requires the web server to serve the compressed file to every client — with nginx that's `gzip_static always;` + `gunzip on;`.

## Other

- Targeted `clear()` now also removes the `.gz` / `.br` siblings so no orphans are left behind. Full clears already sweep the directory.
- README documents the config and the nginx serving side (`gzip_static on;` / `brotli_static on;`).

## Tests

22 passing, including gzip sibling write, compressed-only mode, the "nothing compressed → keep plain" fallback, and sibling cleanup on targeted clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)