### PR TITLE
Add --only-with-query-strings option to static:clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ php artisan static:clear --domain=example.com
 php artisan static:clear --domain=subdomain.example.com
 ```
 
+Clear only the cached files generated for requests with a query string (e.g.
+`/products?page=2`), keeping the plain query-less pages intact:
+
+```bash
+php artisan static:clear --only-with-query-strings
+```
+
 ## Advanced Usage
 
 ### Multi-Domain Support

--- a/src/Commands/StaticClearCommand.php
+++ b/src/Commands/StaticClearCommand.php
@@ -8,10 +8,11 @@ use Illuminate\Console\Command;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route as Router;
+use Illuminate\Support\Str;
 
 class StaticClearCommand extends Command
 {
-    public $signature = 'static:clear {--u|uri=*} {--r|routes=*} {--d|domain=*} {--force : Skip the confirmation prompt}';
+    public $signature = 'static:clear {--u|uri=*} {--r|routes=*} {--d|domain=*} {--only-with-query-strings : Only clear cached files that carry a query string, keeping plain pages} {--force : Skip the confirmation prompt}';
 
     public $description = 'Clear static cached files';
 
@@ -29,6 +30,14 @@ class StaticClearCommand extends Command
         }
 
         $uris = $this->option('uri');
+
+        if ($this->option('only-with-query-strings')) {
+            $cleared = $this->static->clearQueryStrings();
+
+            $this->info('✔ Cleared '.count($cleared).' query string cached '.Str::plural('file', $cleared).'!');
+
+            return self::SUCCESS;
+        }
 
         if (! empty($uris)) {
             $paths = $this->preparePaths($uris);

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -26,6 +26,34 @@ class StaticCache
     }
 
     /**
+     * Clear only the cached files that were generated for a request carrying a
+     * query string, leaving the plain (query-less) pages untouched.
+     *
+     * Cached filenames always embed a "?" delimiter before the extension: a
+     * query-less page is stored as "page?.html", while a query-string variant is
+     * stored as "page?foo=bar.html". A non-empty query string is therefore any
+     * file whose "?" is followed by something other than the extension dot —
+     * which also matches the ".gz"/".br" siblings without extra work.
+     *
+     * @return array<int, string> the paths that were deleted
+     */
+    public function clearQueryStrings(): array
+    {
+        $disk = $this->disk();
+
+        $paths = collect($disk->allFiles())
+            ->filter(fn (string $path): bool => (bool) preg_match('/\?[^.]/', basename($path)))
+            ->values()
+            ->all();
+
+        if (! empty($paths)) {
+            $disk->delete($paths);
+        }
+
+        return $paths;
+    }
+
+    /**
      * Expand a list of static file paths to also include their precompressed
      * siblings (.gz / .br), so a targeted clear doesn't leave orphaned compressed
      * copies behind. Deleting a path that doesn't exist is a harmless no-op.

--- a/tests/Feature/StaticCacheTest.php
+++ b/tests/Feature/StaticCacheTest.php
@@ -198,6 +198,34 @@ it('removes compressed siblings on a targeted clear', function () {
     $disk->assertMissing('localhost/GET/drop?.html.gz');
 });
 
+it('clears only cached files carrying a query string', function () {
+    config([
+        'static.files.disk' => 'local',
+        'static.compression.gzip' => true,
+        'static.files.include_query_string' => true,
+    ]);
+
+    $disk = StaticCache::disk();
+
+    Route::get('reports', fn () => 'report')
+        ->middleware(StaticResponse::class);
+
+    $this->get('reports');
+    $this->get('reports?year=2026');
+
+    $disk->assertExists('localhost/GET/reports?.html');
+    $disk->assertExists('localhost/GET/reports?.html.gz');
+    $disk->assertExists('localhost/GET/reports?year=2026.html');
+    $disk->assertExists('localhost/GET/reports?year=2026.html.gz');
+
+    StaticCache::clearQueryStrings();
+
+    $disk->assertExists('localhost/GET/reports?.html');
+    $disk->assertExists('localhost/GET/reports?.html.gz');
+    $disk->assertMissing('localhost/GET/reports?year=2026.html');
+    $disk->assertMissing('localhost/GET/reports?year=2026.html.gz');
+});
+
 it('minifies HTML', function () {
     config([
         'static.files.disk' => 'local',


### PR DESCRIPTION
## Summary

Adds an option to `static:clear` that clears **only** cached files generated for requests carrying a query string, keeping the plain query-less pages intact.

Cached filenames embed a `?` delimiter before the extension:
- `/products` → `products?.html` (kept)
- `/products?page=2` → `products?page=2.html` (cleared)

## Changes

- **`StaticCache::clearQueryStrings()`** — lists all cached files and deletes those whose filename carries a non-empty query string, including their `.gz`/`.br` siblings. Returns the deleted paths.
- **`static:clear --only-with-query-strings`** — new flag wiring the command to that method, reporting how many files were cleared. Still respects the confirmation prompt / `--force`.
- Test covering that query-string variants (and their gzip siblings) are removed while the base page survives.
- README documentation.

## Testing

`vendor/bin/pest` — 23 passed (55 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)